### PR TITLE
Simplified curl example for obtaining a token

### DIFF
--- a/3.1.1/source/user-management/scim2.md
+++ b/3.1.1/source/user-management/scim2.md
@@ -163,8 +163,9 @@ Here is an example:
 In `curl` jargon, you may issue a command like this to achieve the same effect:
 
 ```
-$ curl -H 'Content-Type: application/x-www-form-urlencoded' -H 'Authorization: Basic ...' 
-       -d grant_type=client_credentials https://<host-name>/oxauth/restv1/token
+$ curl -u '<authUsername>:<authPassword>' \
+       -d grant_type=client_credentials \
+       https://<host-name>/oxauth/restv1/token
 ```
 
 If you have problems creating your request, see section 4.4.2 of [OAuth 2.0](http://tools.ietf.org/html/rfc6749) for a deeper insight.


### PR DESCRIPTION
- the -d argument to curl makes HTTP POST with Conent-type
  application/x-www-form-urlencoded, so there's no need to specify the
  Content-type header.

- the -u <user>:<pass> Creates a Basic Authorization header for you,
  and base 64 encodes the strings.