### PR TITLE
"unsupported_response_type"

### DIFF
--- a/3.1.1/source/integration/sswebapps/openidc-rp.md
+++ b/3.1.1/source/integration/sswebapps/openidc-rp.md
@@ -131,6 +131,7 @@ login uri: https://www.mydomain.com/callback
 Subject Type: Public
 Scopes: openid, profile, email
 Response Types: code
+Grant Types: authorization_code
 
 ```
 
@@ -372,6 +373,7 @@ login uri: https://www.mydomain.com/callback
 Subject Type: Public
 Scopes: openid, profile, email
 Response Types: code
+Grant Types: authorization_code
 ```
 
 !!! Note


### PR DESCRIPTION
Updated with info from https://support.gluu.org/authentication/4506/unsupported_response_type-with-mod_auth_oidc/ as googling the same error lead me to that ticket & adding grant type worked.