### PR TITLE
Corrected doc for the 'Server IP Address' field

### DIFF
--- a/3.1.4/source/user-management/ldap-sync.md
+++ b/3.1.4/source/user-management/ldap-sync.md
@@ -207,9 +207,9 @@ below.
 
 The Gluu Server 3.x introduced two upgraded sections here.
 
-  * _Server IP Address:_ Include the IP of your Gluu Server here. This
-    feature helps to run Cache Refresh mechanism perfectly in a clustered
-    environment.
+  * _Server IP Address:_ Put the IP of the machine running `oxTrust`
+    here. This ensures that the Cache Refresh mechanism runs perfectly
+    in a clustered environment.
 
   * _Removed Script File Name location:_ New version of the Gluu Server
     allows the administrator to manage your custom scripts with more


### PR DESCRIPTION
- Corrected doc for the 'Server IP Address' field of the cache refresh
  mechanism. Putting the wrong IP here makes for very hard errors to
  debug, so being precise here should safe quite a few headaches 😉