### PR TITLE
#86 - Now oxd can be installed with the standard Community Edition setup script (without installing casa)

### DIFF
--- a/docs/source/installation-guide/setup_py.md
+++ b/docs/source/installation-guide/setup_py.md
@@ -25,6 +25,7 @@ Refer to the following table for details about available setup options:
 | Install oxAuth RP | Optional. OpenID Connect test client: useful for test environments, for more details see [here](../admin-guide/openid-connect/#oxauth-rp) |
 | Install Passport |  Optional. Install if you want to support external IDP, for instance to offer users social login. |
 | Install Casa | Optional. Install if you want to support self-service 2FA. More information is available [here](https://gluu.org/docs/casa). Selecting yes also prompts for [oxd installation](https://gluu.org/docs/oxd) |
+| Install oxd | Optional. Install if you want to support simple, static APIs web application developers can use to implement user authentication and authorization against Gluu CE. More information is available [here](https://gluu.org/docs/oxd). |
 | Install Gluu Radius | Optional. Installs Radius server. More information is available [here](../admin-guide/radius-server/gluu-radius.md)
 
 When complete, the setup script will show the selections and prompt for confirmation. If everything looks OK, select Y to finish installation. 


### PR DESCRIPTION
#86 - Now oxd can be installed with the standard Community Edition setup script (without installing casa)
https://github.com/GluuFederation/docs-oxd-prod/issues/86

Now oxd can be installed with the standard Community Edition setup script (without installing casa). Raising PR to add `Install oxd` row in Setup Script docs.
https://www.gluu.org/docs/ce/4.1/4.x-intro/#casa-and-oxd-added-to-installation-script