### PR TITLE
removed invalid parm

### DIFF
--- a/docs/source/api-guide/openid-connect-api.md
+++ b/docs/source/api-guide/openid-connect-api.md
@@ -690,12 +690,6 @@ The Authorization Endpoint performs end-user authentication.
             <td>string</td>
         </tr>
         <tr>
-            <th>amr_values</th>
-            <td>false</td>
-            <td>AMR Values</td>
-            <td>string</td>
-        </tr>
-        <tr>
             <th>request</th>
             <td>false</td>
             <td>This parameter enables OpenID Connect requests to be passed in a single, self-contained parameter and to be optionally signed and/or encrypted. The parameter value is a Request Object value, as specified in section 6.1. It represents the request as a JWT whose Claims are the request parameters.</td>


### PR DESCRIPTION
amr_values is not a real parm to the /authorize endpoint in OIDC.